### PR TITLE
Fix 'Error: write after end at' seen in Lambda

### DIFF
--- a/src/s3_lambda_es.js
+++ b/src/s3_lambda_es.js
@@ -58,14 +58,14 @@ function s3LogsToES(bucket, key, context, lineStream, recordStream) {
       .pipe(recordStream)
       .on('data', function(parsedEntry) {
           postDocumentToES(parsedEntry, context);
-    });
+      });
 
     s3Stream.on('error', function() {
         console.log(
             'Error getting object "' + key + '" from bucket "' + bucket + '".  ' +
             'Make sure they exist and your bucket is in the same region as this function.');
         context.fail();
-      });
+    });
 }
 
 /*

--- a/src/s3_lambda_es.js
+++ b/src/s3_lambda_es.js
@@ -43,27 +43,56 @@ var numDocsAdded = 0;   // Number of log lines added to ES so far
 var creds = new AWS.EnvironmentCredentials('AWS');
 
 
-/* == Streams ==
- * To avoid loading an entire (typically large) log file into memory,
- * this is implemented as a pipeline of filters, streaming log data
- * from S3 to ES.
- * Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
- */
-var lineStream = new LineStream();
-// A stream of log records, from parsing each log line
-var recordStream = new stream.Transform({objectMode: true})
-recordStream._transform = function(line, encoding, done) {
-    var logRecord = parse(line.toString());
-    var serializedRecord = JSON.stringify(logRecord);
-    this.push(serializedRecord);
-    totLogLines ++;
-    done();
-}
+
 
 
 /* Lambda "main": Execution starts here */
 exports.handler = function(event, context) {
     console.log('Received event: ', JSON.stringify(event, null, 2));
+    
+    /* == Streams ==
+    * To avoid loading an entire (typically large) log file into memory,
+    * this is implemented as a pipeline of filters, streaming log data
+    * from S3 to ES.
+    * Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
+    */
+    var lineStream = new LineStream();
+    // A stream of log records, from parsing each log line
+    var recordStream = new stream.Transform({objectMode: true})
+    recordStream._transform = function(line, encoding, done) {
+        var logRecord = parse(line.toString());
+        var serializedRecord = JSON.stringify(logRecord);
+        this.push(serializedRecord);
+        totLogLines ++;
+        done();
+    }
+    
+    /*
+    * Get the log file from the given S3 bucket and key.  Parse it and add
+    * each log record to the ES domain.
+    */
+    function s3LogsToES(bucket, key, context) {
+        // Note: The Lambda function should be configured to filter for .log files
+        // (as part of the Event Source "suffix" setting).
+    
+        var s3Stream = s3.getObject({Bucket: bucket, Key: key}).createReadStream();
+    
+        // Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
+        s3Stream
+        .pipe(lineStream)
+        .pipe(recordStream)
+        .on('data', function(parsedEntry) {
+            postDocumentToES(parsedEntry, context);
+        });
+    
+        s3Stream.on('error', function() {
+            console.log(
+                'Error getting object "' + key + '" from bucket "' + bucket + '".  ' +
+                'Make sure they exist and your bucket is in the same region as this function.');
+            context.fail();
+        });
+    }
+
     event.Records.forEach(function(record) {
         var bucket = record.s3.bucket.name;
         var objKey = decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '));
@@ -71,31 +100,6 @@ exports.handler = function(event, context) {
     });
 }
 
-/*
- * Get the log file from the given S3 bucket and key.  Parse it and add
- * each log record to the ES domain.
- */
-function s3LogsToES(bucket, key, context) {
-    // Note: The Lambda function should be configured to filter for .log files
-    // (as part of the Event Source "suffix" setting).
-
-    var s3Stream = s3.getObject({Bucket: bucket, Key: key}).createReadStream();
-
-    // Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
-    s3Stream
-      .pipe(lineStream)
-      .pipe(recordStream)
-      .on('data', function(parsedEntry) {
-          postDocumentToES(parsedEntry, context);
-      });
-
-    s3Stream.on('error', function() {
-        console.log(
-            'Error getting object "' + key + '" from bucket "' + bucket + '".  ' +
-            'Make sure they exist and your bucket is in the same region as this function.');
-        context.fail();
-    });
-}
 
 /*
  * Add the given document to the ES domain.

--- a/src/s3_lambda_es.js
+++ b/src/s3_lambda_es.js
@@ -42,64 +42,31 @@ var numDocsAdded = 0;   // Number of log lines added to ES so far
  */
 var creds = new AWS.EnvironmentCredentials('AWS');
 
+/*
+* Get the log file from the given S3 bucket and key.  Parse it and add
+* each log record to the ES domain.
+*/
+function s3LogsToES(bucket, key, context, lineStream, recordStream) {
+    // Note: The Lambda function should be configured to filter for .log files
+    // (as part of the Event Source "suffix" setting).
 
+    var s3Stream = s3.getObject({Bucket: bucket, Key: key}).createReadStream();
 
+    // Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
+    s3Stream
+    .pipe(lineStream)
+    .pipe(recordStream)
+    .on('data', function(parsedEntry) {
+        postDocumentToES(parsedEntry, context);
+    });
 
-
-/* Lambda "main": Execution starts here */
-exports.handler = function(event, context) {
-    console.log('Received event: ', JSON.stringify(event, null, 2));
-    
-    /* == Streams ==
-    * To avoid loading an entire (typically large) log file into memory,
-    * this is implemented as a pipeline of filters, streaming log data
-    * from S3 to ES.
-    * Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
-    */
-    var lineStream = new LineStream();
-    // A stream of log records, from parsing each log line
-    var recordStream = new stream.Transform({objectMode: true})
-    recordStream._transform = function(line, encoding, done) {
-        var logRecord = parse(line.toString());
-        var serializedRecord = JSON.stringify(logRecord);
-        this.push(serializedRecord);
-        totLogLines ++;
-        done();
-    }
-    
-    /*
-    * Get the log file from the given S3 bucket and key.  Parse it and add
-    * each log record to the ES domain.
-    */
-    function s3LogsToES(bucket, key, context) {
-        // Note: The Lambda function should be configured to filter for .log files
-        // (as part of the Event Source "suffix" setting).
-    
-        var s3Stream = s3.getObject({Bucket: bucket, Key: key}).createReadStream();
-    
-        // Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
-        s3Stream
-        .pipe(lineStream)
-        .pipe(recordStream)
-        .on('data', function(parsedEntry) {
-            postDocumentToES(parsedEntry, context);
-        });
-    
-        s3Stream.on('error', function() {
-            console.log(
-                'Error getting object "' + key + '" from bucket "' + bucket + '".  ' +
-                'Make sure they exist and your bucket is in the same region as this function.');
-            context.fail();
-        });
-    }
-
-    event.Records.forEach(function(record) {
-        var bucket = record.s3.bucket.name;
-        var objKey = decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '));
-        s3LogsToES(bucket, objKey, context);
+    s3Stream.on('error', function() {
+        console.log(
+            'Error getting object "' + key + '" from bucket "' + bucket + '".  ' +
+            'Make sure they exist and your bucket is in the same region as this function.');
+        context.fail();
     });
 }
-
 
 /*
  * Add the given document to the ES domain.
@@ -139,5 +106,33 @@ function postDocumentToES(doc, context) {
         console.log('Error: ' + err);
         console.log(numDocsAdded + 'of ' + totLogLines + ' log records added to ES.');
         context.fail();
+    });
+}
+
+/* Lambda "main": Execution starts here */
+exports.handler = function(event, context) {
+    console.log('Received event: ', JSON.stringify(event, null, 2));
+    
+    /* == Streams ==
+    * To avoid loading an entire (typically large) log file into memory,
+    * this is implemented as a pipeline of filters, streaming log data
+    * from S3 to ES.
+    * Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
+    */
+    var lineStream = new LineStream();
+    // A stream of log records, from parsing each log line
+    var recordStream = new stream.Transform({objectMode: true})
+    recordStream._transform = function(line, encoding, done) {
+        var logRecord = parse(line.toString());
+        var serializedRecord = JSON.stringify(logRecord);
+        this.push(serializedRecord);
+        totLogLines ++;
+        done();
+    }
+
+    event.Records.forEach(function(record) {
+        var bucket = record.s3.bucket.name;
+        var objKey = decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '));
+        s3LogsToES(bucket, objKey, context, lineStream, recordStream);
     });
 }

--- a/src/s3_lambda_es.js
+++ b/src/s3_lambda_es.js
@@ -43,9 +43,9 @@ var numDocsAdded = 0;   // Number of log lines added to ES so far
 var creds = new AWS.EnvironmentCredentials('AWS');
 
 /*
-* Get the log file from the given S3 bucket and key.  Parse it and add
-* each log record to the ES domain.
-*/
+ * Get the log file from the given S3 bucket and key.  Parse it and add
+ * each log record to the ES domain.
+ */
 function s3LogsToES(bucket, key, context, lineStream, recordStream) {
     // Note: The Lambda function should be configured to filter for .log files
     // (as part of the Event Source "suffix" setting).

--- a/src/s3_lambda_es.js
+++ b/src/s3_lambda_es.js
@@ -54,10 +54,10 @@ function s3LogsToES(bucket, key, context, lineStream, recordStream) {
 
     // Flow: S3 file stream -> Log Line stream -> Log Record stream -> ES
     s3Stream
-    .pipe(lineStream)
-    .pipe(recordStream)
-    .on('data', function(parsedEntry) {
-        postDocumentToES(parsedEntry, context);
+      .pipe(lineStream)
+      .pipe(recordStream)
+      .on('data', function(parsedEntry) {
+          postDocumentToES(parsedEntry, context);
     });
 
     s3Stream.on('error', function() {

--- a/src/s3_lambda_es.js
+++ b/src/s3_lambda_es.js
@@ -65,7 +65,7 @@ function s3LogsToES(bucket, key, context, lineStream, recordStream) {
             'Error getting object "' + key + '" from bucket "' + bucket + '".  ' +
             'Make sure they exist and your bucket is in the same region as this function.');
         context.fail();
-    });
+      });
 }
 
 /*


### PR DESCRIPTION
As can be seen, for example, here:

http://stackoverflow.com/questions/33578998/stream-transformations-in-aws-lambda-result-in-write-after-end-error

This code produces errors from time to time such as:

```
015-11-11T17:31:45.838Z    1485c418-889a-11e5-b074-f563d186ab6b    Error: write after end at writeAfterEnd (_stream_writable.js:133:12) at LineStream.Writable.write (_stream_writable.js:181:5) at write (_stream_readable.js:602:24) at flow (_stream_readable.js:611:7) at PassThrough.pipeOnReadable (_stream_readable.js:643:5) at PassThrough.emit (events.js:92:17) at emitReadable_ (_stream_readable.js:427:10) at emitReadable (_stream_readable.js:423:5) at readableAddChunk (_stream_readable.js:166:9) at PassThrough.Readable.push (_stream_readable.js:128:10)
```

this code fix moves the read stream invocation from global to inside the handler. It eliminated the above errors which were ~ 1/3 of all attempts to invoke the Lambda function. 
