### PR TITLE
Update s3_lambda_es.js

### DIFF
--- a/src/s3_lambda_es.js
+++ b/src/s3_lambda_es.js
@@ -82,7 +82,8 @@ function postDocumentToES(doc, context) {
     req.body = doc;
     req.headers['presigned-expires'] = false;
     req.headers['Host'] = endpoint.host;
-
+    req.headers['Content-Type'] = 'application/json';
+    
     // Sign the request (Sigv4)
     var signer = new AWS.Signers.V4(req, 'es');
     signer.addAuthorization(creds, new Date());


### PR DESCRIPTION
Added content-type header. Needed to make it work with ES 6.x
See https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests